### PR TITLE
Respect `database.url` Rails config if present.

### DIFF
--- a/lib/brillo/adapter/mysql.rb
+++ b/lib/brillo/adapter/mysql.rb
@@ -27,7 +27,19 @@ module Brillo
       def load_command
         host = config['host'] ? "--host #{config['host']}" : ''
         password = config['password'] ? "-p'#{config['password']}'" : ''
-        "mysql #{host} -u #{config.fetch('username')} #{password} #{config.fetch('database')}"
+        # If present, the database.yml url parameter should take precedence.
+        if (url = config['url'])
+          uri = URI.parse(url)
+          password = uri.password ? "-p'#{uri.password}'" : ''
+          # We set the URI password component to nil because it's handled by the `-p` flag and will
+          # be masked later on (see the `log_anonymized' method).
+          uri.password = nil
+          command_parameters = "#{uri} #{password}"
+        else
+          command_parameters = "#{host} -u #{config.fetch('username')} #{password} #{config.fetch('database')}"
+        end
+
+        "mysql #{command_parameters}"
       end
     end
   end

--- a/lib/brillo/adapter/mysql.rb
+++ b/lib/brillo/adapter/mysql.rb
@@ -25,9 +25,9 @@ module Brillo
       end
 
       def load_command
-        host = config["host"] ? "--host #{config["host"]}" : ""
-        password = config["password"] ? "-p#{config["password"]}" : ""
-        "mysql #{host} -u #{config.fetch("username")} #{password} #{config.fetch("database")}"
+        host = config['host'] ? "--host #{config['host']}" : ''
+        password = config['password'] ? "-p'#{config['password']}'" : ''
+        "mysql #{host} -u #{config.fetch('username')} #{password} #{config.fetch('database')}"
       end
     end
   end

--- a/lib/brillo/adapter/mysql.rb
+++ b/lib/brillo/adapter/mysql.rb
@@ -26,20 +26,20 @@ module Brillo
 
       def load_command
         host = config['host'] ? "--host #{config['host']}" : ''
-        password = config['password'] ? "-p'#{config['password']}'" : ''
+        password = config['password'] ? "MYSQL_PWD='#{config['password']}' " : ''
         # If present, the database.yml url parameter should take precedence.
         if (url = config['url'])
           uri = URI.parse(url)
-          password = uri.password ? "-p'#{uri.password}'" : ''
+          password = uri.password ? "MYSQL_PWD='#{uri.password}' " : ''
           # We set the URI password component to nil because it's handled by the `-p` flag and will
           # be masked later on (see the `log_anonymized' method).
           uri.password = nil
-          command_parameters = "#{uri} #{password}"
+          command_parameters = uri
         else
-          command_parameters = "#{host} -u #{config.fetch('username')} #{password} #{config.fetch('database')}"
+          command_parameters = "#{host} -u #{config.fetch('username')} #{config.fetch('database')}"
         end
 
-        "mysql #{command_parameters}"
+        "#{password}mysql #{command_parameters}"
       end
     end
   end

--- a/lib/brillo/adapter/postgres.rb
+++ b/lib/brillo/adapter/postgres.rb
@@ -2,20 +2,20 @@ module Brillo
   module Adapter
     class Postgres < Base
       def load_command
-        host = config["host"] ? "--host #{config["host"]}" : ""
-        password = config["password"] ? "PGPASSWORD=#{config["password"]} " : ""
-        search_path = config["schema_search_path"] ? "PGOPTIONS=--search_path=#{config["schema_search_path"]} " : ""
+        host = config['host'] ? "--host #{config['host']}" : ''
+        password = config['password'] ? "PGPASSWORD=#{config['password']} " : ''
+        search_path = config['schema_search_path'] ? "PGOPTIONS=--search_path=#{config['schema_search_path']} " : ''
 
         # If present, the database.yml url parameter should take precedence.
-        if url = config["url"]
+        if (url = config['url'])
           uri = URI.parse(url)
           password = uri.password
-          uri.password = nil # We set the URI password component to nil because it's handled by the
-                             # PGPASSWORD environment variable and will be masked later on (see the
-                             # `log_anonymized' method).
+          # We set the URI password component to nil because it's handled by the PGPASSWORD
+          # environment variable and will be masked later on (see the `log_anonymized' method).
+          uri.password = nil
           command_parameters = uri
         else
-          command_parameters = "#{host} -U #{config.fetch("username")} #{config.fetch("database")}"
+          command_parameters = "#{host} -U #{config.fetch('username')} #{config.fetch('database')}"
         end
 
         inline_options = password + search_path

--- a/lib/brillo/helpers/exec_helper.rb
+++ b/lib/brillo/helpers/exec_helper.rb
@@ -11,11 +11,9 @@ module Brillo
 
       def execute!(*command)
         success, stdout, stderr = execute(command)
-        if success
-          [success, stdout, stderr]
-        else
-          raise RuntimeError, "#{stdout} #{stderr}"
-        end
+        raise "#{stdout} #{stderr}" unless success
+
+        [success, stdout, stderr]
       end
 
       private

--- a/lib/brillo/helpers/exec_helper.rb
+++ b/lib/brillo/helpers/exec_helper.rb
@@ -21,6 +21,7 @@ module Brillo
       private
 
       def log_anonymized(command_string)
+        command_string = command_string.gsub(/MYSQL_PWD=[^\s]+/, 'MYSQL_PWD={FILTERED}')
         command_string = command_string.gsub(/PGPASSWORD=[^\s]+/, 'PGPASSWORD={FILTERED}')
         command_string = command_string.gsub(/--password=[^\s]+/, '--password={FILTERED}')
         command_string = command_string.gsub(/EC2_ACCESS_KEY=[^\s]+/, 'EC2_ACCESS_KEY={FILTERED}')

--- a/lib/brillo/helpers/exec_helper.rb
+++ b/lib/brillo/helpers/exec_helper.rb
@@ -21,10 +21,10 @@ module Brillo
       private
 
       def log_anonymized command_string
-        command_string = command_string.gsub(/PGPASSWORD=[^\s]+/, "PGPASSWORD={FILTERED}")
-        command_string = command_string.gsub(/--password=[^\s]+/, "--password={FILTERED}")
-        command_string = command_string.gsub(/EC2_ACCESS_KEY=[^\s]+/, "EC2_ACCESS_KEY={FILTERED}")
-        command_string = command_string.gsub(/EC2_SECRET_KEY=[^\s]+/, "EC2_SECRET_KEY={FILTERED}")
+        command_string = command_string.gsub(/PGPASSWORD=[^\s]+/, 'PGPASSWORD={FILTERED}')
+        command_string = command_string.gsub(/--password=[^\s]+/, '--password={FILTERED}')
+        command_string = command_string.gsub(/EC2_ACCESS_KEY=[^\s]+/, 'EC2_ACCESS_KEY={FILTERED}')
+        command_string = command_string.gsub(/EC2_SECRET_KEY=[^\s]+/, 'EC2_SECRET_KEY={FILTERED}')
         logger.info "Running \n\t #{command_string}"
       end
     end

--- a/lib/brillo/helpers/exec_helper.rb
+++ b/lib/brillo/helpers/exec_helper.rb
@@ -2,14 +2,14 @@ require 'open3'
 module Brillo
   module Helpers
     module ExecHelper
-      def execute *command
+      def execute(*command)
         command_string = Array(command).join(' ')
         log_anonymized command_string
         stdout, stderr, status = Open3.capture3 command_string
         [status.success?, stdout, stderr]
       end
 
-      def execute! *command
+      def execute!(*command)
         success, stdout, stderr = execute(command)
         if success
           [success, stdout, stderr]
@@ -20,7 +20,7 @@ module Brillo
 
       private
 
-      def log_anonymized command_string
+      def log_anonymized(command_string)
         command_string = command_string.gsub(/PGPASSWORD=[^\s]+/, 'PGPASSWORD={FILTERED}')
         command_string = command_string.gsub(/--password=[^\s]+/, '--password={FILTERED}')
         command_string = command_string.gsub(/EC2_ACCESS_KEY=[^\s]+/, 'EC2_ACCESS_KEY={FILTERED}')


### PR DESCRIPTION
The intention is to still work exactly the same as before if users are using `user`, `password`, etc. from `database.yml`, but now also support the `url` field which if i understand correctly should take precedence.

I've attempted to write this in such a way that existing behaviour is preserved.  In particular, the log anonimisation technique is handy, so i'm pulling the password out of the URI.

Fixes #29.